### PR TITLE
Halt prerelease scraping until page is fixed

### DIFF
--- a/.github/workflows/cpy_cron.yml
+++ b/.github/workflows/cpy_cron.yml
@@ -32,7 +32,10 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.9'
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
 
     - name: Update pip
       run: python -m pip install -U pip

--- a/.github/workflows/cpy_cron.yml
+++ b/.github/workflows/cpy_cron.yml
@@ -21,7 +21,7 @@ on:
 
 
 jobs:
-  link_check:
+  feedgen:
     name: Update CPython release feed
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cpy_cron.yml
+++ b/.github/workflows/cpy_cron.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/make_feed.py
+++ b/make_feed.py
@@ -220,9 +220,11 @@ def main():
     logger.info("Base feed generator created")
 
     # Pre-release(s) first so that they populate at the head of the
-    # feed
-    [add_feed_item(fg, extract_pre_info(body)) for body in gen_pre_entries(resp_pre)]
-    logger.info("Prereleases added to feed")
+    # feed.
+    # SKIPPED since the prereleases page is currently missing.
+    # [add_feed_item(fg, extract_pre_info(body)) for body in gen_pre_entries(resp_pre)]
+    # logger.info("Prereleases added to feed")
+    logger.info("Pre-releases skipped due to missing python.org pre-release page")
 
     [
         add_feed_item(fg, extract_stable_info(li))


### PR DESCRIPTION
The python.org prereleases page is not working; it's redirecting back to the downloads page.

Naturally, this is breaking the scraping.

We'll comment out the prerelease code for now.